### PR TITLE
change androidx.core:core-ktx version to 1.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,6 +61,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }


### PR DESCRIPTION
Today I tried to use @capacitor-community/bluetooth-le@0.x
but after installing plugin I got this error at build time (android only)
```
~/.gradle/caches/transforms-2/files-2.1/462cf05f81b7c169f5ede52434de8415/core-1.7.0-alpha02/res/values/values.xml:105:5-114:25: AAPT: error: resource android:attr/lStar not found.
```

following this [suggestion](https://stackoverflow.com/questions/69021225/resource-linking-fails-on-lstar/69031863#69031863) resolved my issue