### PR TITLE
Fix `numberToUUID` for values with leading zeroes

### DIFF
--- a/src/conversion.spec.ts
+++ b/src/conversion.spec.ts
@@ -54,6 +54,12 @@ describe('numberToUUID', () => {
     const result = numberToUUID(value);
     expect(result).toEqual('0000180d-0000-1000-8000-00805f9b34fb');
   });
+
+  it('should also work with leading zeroes', () => {
+    const value = 0x0042;
+    const result = numberToUUID(value);
+    expect(result).toEqual('00000042-0000-1000-8000-00805f9b34fb');
+  });
 });
 
 describe('hexStringToDataView', () => {

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -32,7 +32,7 @@ export function dataViewToText(value: DataView): string {
  * @return string, e.g. '0000180d-0000-1000-8000-00805f9b34fb'
  */
 export function numberToUUID(value: number): string {
-  return `0000${value.toString(16)}-0000-1000-8000-00805f9b34fb`;
+  return `0000${value.toString(16).padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
 }
 
 export function hexStringToDataView(value: string): DataView {


### PR DESCRIPTION
For values with leading zeroes (e.g. `0x0042`), the `numberToUUID` function would drop the leading zeroes, leading to an invalid UUID.
This pull request would make sure that the leading zeroes are added if necessary (using [`String.prototype.padStart()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart)).