### PR TITLE
Fix crash stopScanning with BLE adapter off #317

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -353,7 +353,12 @@ class BluetoothLe : Plugin() {
     @PluginMethod
     fun stopLEScan(call: PluginCall) {
         assertBluetoothAdapter(call) ?: return
-        deviceScanner?.stopScanning()
+        try {
+            deviceScanner?.stopScanning()
+        }
+        catch (e: IllegalStateException) {
+            Log.e(TAG, "Error in stopLEScan: ${e.localizedMessage}")
+        }
         call.resolve()
     }
 


### PR DESCRIPTION
Wrap call to `deviceScanner?.stopScanning()` in a try ... catch block to ignore `IllegalStateException`