### PR TITLE
fix(android): fix concurrency issue in timeoutmap(#419)

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
@@ -24,16 +24,17 @@ class TimeoutHandler(
 )
 
 fun <T> ConcurrentLinkedQueue<T>.popFirstMatch(predicate: (T) -> Boolean): T? {
-    val removed = AtomicReference<T>()
-    this.removeIf { item ->
-        if (removed.get() == null && predicate(item)) {
-            removed.set(item)
-            true
-        } else {
-            false
+    synchronized(this) {
+        val iterator = this.iterator()
+        while (iterator.hasNext()) {
+            val nextItem = iterator.next()
+            if (predicate(nextItem)) {
+                iterator.remove()
+                return nextItem
+            }
         }
+        return null
     }
-    return removed.get()
 }
 
 class Device(


### PR DESCRIPTION
Hashmap is not thread safe, which will lead to errors as mentioned in the #419. We suggest a concurrent queue for storing and accessing the timeout handlers in a safe way.