### PR TITLE
fix(ios): fix multiple instances of same device object during ble scan

### DIFF
--- a/ios/Plugin/DeviceManager.swift
+++ b/ios/Plugin/DeviceManager.swift
@@ -153,9 +153,14 @@ class DeviceManager: NSObject, CBCentralManagerDelegate {
         guard self.passesNameFilter(peripheralName: peripheral.name) else { return }
         guard self.passesNamePrefixFilter(peripheralName: peripheral.name) else { return }
 
-        let device = Device(peripheral)
+        let device: Device
+        if self.allowDuplicates, let knownDevice = discoveredDevices.first(where: { $0.key == peripheral.identifier.uuidString })?.value {
+            device = knownDevice
+        } else {
+            device = Device(peripheral)
+            self.discoveredDevices[device.getId()] = device
+        }
         log("New device found: ", device.getName() ?? "Unknown")
-        self.discoveredDevices[device.getId()] = device
 
         if shouldShowDeviceList {
             DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
Allowing duplicates for ble scanning on ios is messing up the peripheral delegate callbacks due to the construction of a new Device object on every discovery callback. This leads to timeouts in all kinds of callbacks inside the Device class if the scan stays active during connecting, because only the most recent Device instance gets the peripheral callbacks.

This proposed fix only constructs a single Device object per peripheral.

For debugging purposes we have added some logs that clearly show this issue.

```
⚡️  To Native ->  BluetoothLe initialize 111738470
⚡️  [log] - start scanning
⚡️  To Native ->  OverlayCamera stopPreview 111738471
⚡️  TO JS undefined
⚡️  BluetoothLe - Resolve initialize BLE powered on
⚡️  TO JS undefined
⚡️  To Native ->  BluetoothLe addListener 111738472
⚡️  To Native ->  BluetoothLe requestLEScan 111738473
⚡️  BluetoothLe - Resolve startScanning Scan started.
⚡️  TO JS undefined
[BLE] Device 5FBB58D1-47F1-40A5-A3ED-FE394CF27629 initialized for name: IMU_8e3f7f
⚡️  BluetoothLe - New device found:  IMU_8e3f7f
⚡️  TO JS {"rssi":-60,"localName":"IMU_8e3f7f","uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"txPower":127,"manufacturerData":{"89":"01 00 64 63 "},"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
⚡️  [log] - received new scan result: {"rssi":-60,"localName":"IMU_8e3f7f","uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"txPower":127,"manufacturerData":{"89":{}},"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
[BLE] Device 1B988F6D-838F-4FCA-A0CD-49C991B6988F initialized for name: IMU_8e3f7f
⚡️  BluetoothLe - New device found:  IMU_8e3f7f
⚡️  TO JS {"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","device":{"name":"IMU_8e3f7f","deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52"},"rssi":-65,"txPower":127,"manufacturerData":{"89":"01 00 64 63 "}}
⚡️  [log] - received new scan result: {"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","device":{"name":"IMU_8e3f7f","deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52"},"rssi":-65,"txPower":127,"manufacturerData":{"89":{}}}
⚡️  [log] - Babylon.js v6.25.0 - WebGL2 - Parallel shader compilation
[BLE] Device 6E6C243C-C347-42FF-A8BC-A1F6C6975E45 initialized for name: IMU_8e3f7f
⚡️  BluetoothLe - New device found:  IMU_8e3f7f
⚡️  TO JS {"rssi":-63,"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","manufacturerData":{"89":"01 00 64 63 "},"txPower":127,"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
[BLE] Device A73FD2F9-4707-42E9-9E17-2FB565803FC6 initialized for name: IMU_8e3f7f
⚡️  BluetoothLe - New device found:  IMU_8e3f7f
⚡️  TO JS {"rssi":-63,"device":{"name":"IMU_8e3f7f","deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52"},"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"manufacturerData":{"89":"01 01 64 61 "},"txPower":127,"localName":"IMU_8e3f7f"}
⚡️  [log] - received new scan result: {"rssi":-63,"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","manufacturerData":{"89":{}},"txPower":127,"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
⚡️  [log] - received new scan result: {"rssi":-63,"device":{"name":"IMU_8e3f7f","deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52"},"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"manufacturerData":{"89":{}},"txPower":127,"localName":"IMU_8e3f7f"}
⚡️  To Native ->  BluetoothLe addListener 111738474
⚡️  To Native ->  BluetoothLe connect 111738475
[BLE] 2023-11-01 12:28:02 +0000 callbackMap of device A73FD2F9-4707-42E9-9E17-2FB565803FC6 contains keys: ["connect"]
[BLE] 2023-11-01 12:28:02 +0000 timeout for key connect created
⚡️  BluetoothLe - Connecting to peripheral <CBPeripheral: 0x6000026ae220, identifier = 38E794BA-6B6F-BD3F-6501-29C6BA367A52, name = IMU_8e3f7f, mtu = 0, state = disconnected>
[BLE] Device 4FE917F2-A89B-473F-8558-62870CD8E8F5 initialized for name: IMU_8e3f7f
⚡️  BluetoothLe - New device found:  IMU_8e3f7f
⚡️  TO JS {"manufacturerData":{"89":"01 01 64 61 "},"txPower":127,"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","rssi":-64,"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
⚡️  [log] - received new scan result: {"manufacturerData":{"89":{}},"txPower":127,"uuids":["80030001-e629-4c98-9324-aa7fc0c66de7"],"localName":"IMU_8e3f7f","rssi":-64,"device":{"deviceId":"38E794BA-6B6F-BD3F-6501-29C6BA367A52","name":"IMU_8e3f7f"}}
⚡️  BluetoothLe - Connected to device <CBPeripheral: 0x6000026ae220, identifier = 38E794BA-6B6F-BD3F-6501-29C6BA367A52, name = IMU_8e3f7f, mtu = 247, state = connected>
⚡️  BluetoothLe - Resolve connect|38E794BA-6B6F-BD3F-6501-29C6BA367A52 Successfully connected.
⚡️  BluetoothLe - Connected to peripheral. Waiting for service discovery.
⚡️  BluetoothLe - didDiscoverServices
⚡️  BluetoothLe - didDiscoverCharacteristicsFor 1 1
[BLE] More services: 1/1 characteristics: 0 / 2 have to be discovered
[BLE] More services: 1/1 characteristics: 1 / 2 have to be discovered
[BLE] Enough services and characteristics found
[BLE] 2023-11-01 12:28:03 +0000 Resolve for key connect in device 4FE917F2-A89B-473F-8558-62870CD8E8F5 ... Valid keys: []
[BLE] no callback for key connect
[BLE] 2023-11-01 12:28:03 +0000 Resolve for key discoverServices in device 4FE917F2-A89B-473F-8558-62870CD8E8F5 ... Valid keys: []
[BLE] no callback for key discoverServices
[BLE] 2023-11-01 12:28:13 +0000 Reject for key connect in device A73FD2F9-4707-42E9-9E17-2FB565803FC6 ... Valid keys: ["connect"]
⚡️  BluetoothLe - Reject connect Connection timeout
[BLE] 2023-11-01 12:28:13 +0000 callbackMap of device A73FD2F9-4707-42E9-9E17-2FB565803FC6 contains keys: []
[BLE] 2023-11-01 12:28:13 +0000 timeout for key connect cancelled
ERROR MESSAGE:  {"message":"Connection timeout","errorMessage":"Connection timeout"}
⚡️  [error] - {"message":"Connection timeout","errorMessage":"Connection timeout"}
```