### PR TITLE
fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ _Note_: web support depends on the browser, see [implementation status](https://
 | [`readRssi(...)`](#readrssi)                                   |   ✅    | ✅  | ❌  |
 | [`read(...)`](#read)                                           |   ✅    | ✅  | ✅  |
 | [`write(...)`](#write)                                         |   ✅    | ✅  | ✅  |
-| [`readDescriptor(...)`](#read)                                 |   ✅    | ✅  | ✅  |
-| [`writeDescriptor(...)`](#write)                               |   ✅    | ✅  | ✅  |
+| [`readDescriptor(...)`](#readdescriptor)                                 |   ✅    | ✅  | ✅  |
+| [`writeDescriptor(...)`](#writedescriptor)                               |   ✅    | ✅  | ✅  |
 | [`writeWithoutResponse(...)`](#writewithoutresponse)           |   ✅    | ✅  | ✅  |
 | [`startNotifications(...)`](#startnotifications)               |   ✅    | ✅  | ✅  |
 | [`stopNotifications(...)`](#stopnotifications)                 |   ✅    | ✅  | ✅  |


### PR DESCRIPTION
Hello,

I found two links in the readme which were pointing to the wrong part of the docs so I fixed them.

