### PR TITLE
Improvement add new params timeout for disconnect 

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
@@ -423,16 +423,28 @@ class Device(
         return device.bondState == BluetoothDevice.BOND_BONDED
     }
 
-    fun disconnect(
-        timeout: Long, callback: (CallbackResponse) -> Unit
-    ) {
+    fun disconnect(timeout: Long, callback: (CallbackResponse) -> Unit) {
         val key = "disconnect"
         callbackMap[key] = callback
-        if (bluetoothGatt == null) {
-            resolve(key, "Disconnected.")
+
+        // Add a listener for Bluetooth status to dynamically handle status changes
+        val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        if (!bluetoothAdapter.isEnabled) {
+            // If Bluetooth is disabled, immediately inform the callback of the disconnection failure
+            resolve(key, "Failed: Bluetooth is turned off.")
             return
         }
+
+        // If bluetoothGatt is null, this means that the connection is no longer active or was never established
+        if (bluetoothGatt == null) {
+            resolve(key, "Disconnected: No active connection.")
+            return
+        }
+
+        // Proceed with disconnection
         bluetoothGatt?.disconnect()
+
+        // Set a timeout for disconnection
         setTimeout(key, "Disconnection timeout.", timeout)
     }
 

--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -488,9 +488,9 @@ class BleClientClass implements BleClientInterface {
     return isBonded;
   }
 
-  async disconnect(deviceId: string): Promise<void> {
+  async disconnect(deviceId: string, options?: TimeoutOptions): Promise<void> {
     await this.queue(async () => {
-      await BluetoothLe.disconnect({ deviceId });
+      await BluetoothLe.disconnect({ deviceId, ...options });
     });
   }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -295,7 +295,7 @@ export interface BluetoothLePlugin {
   connect(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   createBond(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   isBonded(options: DeviceIdOptions): Promise<BooleanResult>;
-  disconnect(options: DeviceIdOptions): Promise<void>;
+  disconnect(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   getServices(options: DeviceIdOptions): Promise<BleServices>;
   discoverServices(options: DeviceIdOptions): Promise<void>;
   getMtu(options: DeviceIdOptions): Promise<GetMtuResult>;


### PR DESCRIPTION
Hello, I added a new timeout parameter for disconnection, I found it strange but the wrapper (typescript) to the native code does not expose 'timeout' while in the function definition of the native code can very do it well! One forgets ? Here is a PR and related to this issue: https://github.com/capacitor-community/bluetooth-le/issues/644