### PR TITLE
Improvement: add timeout options for api disconnect

### DIFF
--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -164,8 +164,9 @@ export interface BleClientInterface {
   /**
    * Disconnect from a peripheral BLE device. For an example, see [usage](#usage).
    * @param deviceId  The ID of the device to use (obtained from [requestDevice](#requestDevice) or [requestLEScan](#requestLEScan))
+   * @param options Options for plugin call
    */
-  disconnect(deviceId: string): Promise<void>;
+  disconnect(deviceId: string, options?: TimeoutOptions): Promise<void>;
 
   /**
    * Get services, characteristics and descriptors of a device.
@@ -488,9 +489,9 @@ class BleClientClass implements BleClientInterface {
     return isBonded;
   }
 
-  async disconnect(deviceId: string): Promise<void> {
+  async disconnect(deviceId: string, options?: TimeoutOptions): Promise<void> {
     await this.queue(async () => {
-      await BluetoothLe.disconnect({ deviceId });
+      await BluetoothLe.disconnect({ deviceId, ...options });
     });
   }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -295,7 +295,7 @@ export interface BluetoothLePlugin {
   connect(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   createBond(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   isBonded(options: DeviceIdOptions): Promise<BooleanResult>;
-  disconnect(options: DeviceIdOptions): Promise<void>;
+  disconnect(options: DeviceIdOptions & TimeoutOptions): Promise<void>;
   getServices(options: DeviceIdOptions): Promise<BleServices>;
   discoverServices(options: DeviceIdOptions): Promise<void>;
   getMtu(options: DeviceIdOptions): Promise<GetMtuResult>;


### PR DESCRIPTION
Hello, I added a new timeout parameter for disconnection, I found it strange but the wrapper (typescript) to the native code does not expose 'timeout' while in the function definition of the native code can very do it well! One forgets ? Here is a PR and related to this issue: https://github.com/capacitor-community/bluetooth-le/issues/644