### PR TITLE
feat(android): use pending intent in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,7 @@ Stop listening to the changes of the value of a characteristic. For an example, 
 | **`optionalServices`** | <code>string[]</code>                         | For **web**, all services that will be used have to be listed under services or optionalServices, e.g. [numberToUUID(0x180f)] (see [UUID format](#uuid-format))                                                                                           |
 | **`allowDuplicates`**  | <code>boolean</code>                          | Normally scans will discard the second and subsequent advertisements from a single device. If you need to receive them, set allowDuplicates to true (only applicable in `requestLEScan`). (default: false)                                                |
 | **`scanMode`**         | <code><a href="#scanmode">ScanMode</a></code> | Android scan mode (default: <a href="#scanmode">ScanMode.SCAN_MODE_BALANCED</a>)                                                                                                                                                                          |
+| **`usePendingIntent`** | <code>boolean</code>                          | Use pending intent for scan results for background scanning. (Android only) https://developer.android.com/develop/connectivity/bluetooth/ble/background#find-device                                                                                       |
 
 #### ScanResult
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,5 +19,15 @@
   <uses-feature
     android:name="android.hardware.bluetooth_le"
     android:required="false" />
+
+  <application>
+    <receiver android:name="com.capacitorjs.community.plugins.bluetoothle.BleScanReceiver"
+        android:exported="false">
+      <intent-filter>
+        <action android:name="com.capacitorjs.community.plugins.bluetoothle.ACTION_FOUND" />
+      </intent-filter>
+    </receiver>
+  </application>
+
 </manifest>
   

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BleScanReceiver.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BleScanReceiver.kt
@@ -1,0 +1,37 @@
+package com.capacitorjs.community.plugins.bluetoothle
+
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+class BleScanReceiver : BroadcastReceiver() {
+    companion object {
+        var scanCallback: ScanCallback? = null  // Reference to the existing ScanCallback
+        var action = "com.capacitorjs.community.plugins.bluetoothle.ACTION_FOUND"
+        private val TAG = BleScanReceiver::class.java.simpleName
+    }
+
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onReceive(context: Context?, intent: Intent?) {
+            val results: List<ScanResult>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                // For Android 13 and above
+                intent?.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT, ScanResult::class.java)
+            } else {
+                // For Android 12 and below
+                @Suppress("DEPRECATION")
+                intent?.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT)
+            }
+
+            results?.forEach { result ->
+                // Forward the results to the ScanCallback
+                scanCallback?.onScanResult(ScanSettings.CALLBACK_TYPE_ALL_MATCHES, result)
+            }
+        }
+}

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -310,6 +310,7 @@ class BluetoothLe : Plugin() {
         val scanFilters = getScanFilters(call) ?: return
         val scanSettings = getScanSettings(call) ?: return
         val namePrefix = call.getString("namePrefix", "") as String
+        val usePendingIntent = call.getBoolean("usePendingIntent", false ) as Boolean
 
         try {
             deviceScanner?.stopScanning()
@@ -327,7 +328,7 @@ class BluetoothLe : Plugin() {
             showDialog = true,
         )
         deviceScanner?.startScanning(
-            scanFilters, scanSettings, false, namePrefix, { scanResponse ->
+            scanFilters, scanSettings, false, namePrefix, usePendingIntent, { scanResponse ->
                 run {
                     if (scanResponse.success) {
                         if (scanResponse.device == null) {
@@ -352,6 +353,7 @@ class BluetoothLe : Plugin() {
         val scanSettings = getScanSettings(call) ?: return
         val namePrefix = call.getString("namePrefix", "") as String
         val allowDuplicates = call.getBoolean("allowDuplicates", false) as Boolean
+        val usePendingIntent = call.getBoolean("usePendingIntent", false) as Boolean // Get the flag from JS
 
         try {
             deviceScanner?.stopScanning()
@@ -372,6 +374,7 @@ class BluetoothLe : Plugin() {
             scanSettings,
             allowDuplicates,
             namePrefix,
+            usePendingIntent,
             { scanResponse ->
                 run {
                     if (scanResponse.success) {

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/DeviceScanner.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/DeviceScanner.kt
@@ -2,6 +2,7 @@ package com.capacitorjs.community.plugins.bluetoothle
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.app.PendingIntent
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.le.ScanCallback
@@ -9,6 +10,8 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.widget.ArrayAdapter
@@ -52,6 +55,7 @@ class DeviceScanner(
     private var stopScanHandler: Handler? = null
     private var allowDuplicates: Boolean = false
     private var namePrefix: String = ""
+    private var usePendingIntent: Boolean = false
 
     private val scanCallback: ScanCallback = object : ScanCallback() {
         override fun onScanResult(callbackType: Int, result: ScanResult) {
@@ -82,6 +86,7 @@ class DeviceScanner(
         scanSettings: ScanSettings,
         allowDuplicates: Boolean,
         namePrefix: String,
+        usePendingIntent: Boolean, // Flag to control PendingIntent vs ScanCallback
         callback: (ScanResponse) -> Unit,
         scanResultCallback: ((ScanResult) -> Unit)?
     ) {
@@ -89,14 +94,36 @@ class DeviceScanner(
         this.scanResultCallback = scanResultCallback
         this.allowDuplicates = allowDuplicates
         this.namePrefix = namePrefix
+        this.usePendingIntent = usePendingIntent
 
         deviceStrings.clear()
         deviceList.clear()
+
         if (!isScanning) {
             setTimeoutForStopScanning()
-            Logger.debug(TAG, "Start scanning.")
+            Logger.debug(TAG, "Start scanning" + (if (usePendingIntent) " with pendingIntent!" else "."))
             isScanning = true
-            bluetoothLeScanner?.startScan(scanFilters, scanSettings, scanCallback)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && usePendingIntent) {
+                // Use PendingIntent for background scanning
+                val intent = Intent(context, BleScanReceiver::class.java).setAction(BleScanReceiver.action)
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                )
+
+                // Store the ScanCallback inside the BroadcastReceiver
+                BleScanReceiver.scanCallback = scanCallback
+
+                // Start the scan with PendingIntent
+                bluetoothLeScanner?.startScan(scanFilters, scanSettings, pendingIntent)
+            } else {
+                // Use ScanCallback for foreground scanning
+                bluetoothLeScanner?.startScan(scanFilters, scanSettings, scanCallback)
+            }
+
             if (showDialog) {
                 dialogHandler = Handler(Looper.getMainLooper())
                 showDeviceList()
@@ -133,7 +160,21 @@ class DeviceScanner(
         }
         Logger.debug(TAG, "Stop scanning.")
         isScanning = false
-        bluetoothLeScanner?.stopScan(scanCallback)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && usePendingIntent) {
+            // Stop scan using PendingIntent
+            val intent = Intent(context, BleScanReceiver::class.java).setAction(BleScanReceiver.action)
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            )
+            bluetoothLeScanner?.stopScan(pendingIntent)
+        } else {
+            // Stop scan using ScanCallback
+            bluetoothLeScanner?.stopScan(scanCallback)
+        }
     }
 
     private fun showDeviceList() {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -46,6 +46,12 @@ export interface RequestBleDeviceOptions {
    * Android scan mode (default: ScanMode.SCAN_MODE_BALANCED)
    */
   scanMode?: ScanMode;
+
+  /**
+   * Use pending intent for scan results for background scanning. (Android only)
+   * https://developer.android.com/develop/connectivity/bluetooth/ble/background#find-device
+   */
+  usePendingIntent?: boolean;
 }
 
 /**


### PR DESCRIPTION
fixes https://github.com/capacitor-community/bluetooth-le/issues/699

adding an optional parameter that ensures Android will use a pending intent for scan results