### PR TITLE
perf: byte to hex string conversion optimizations

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Conversion.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Conversion.kt
@@ -1,13 +1,28 @@
 package com.capacitorjs.community.plugins.bluetoothle
 
+// Create a LUT for high performance ByteArray conversion
+val HEX_LOOKUP_TABLE = IntArray(256) {
+    val hexChars = "0123456789abcdef"
+    val h: Int = (hexChars[(it shr 4)].code shl 8)
+    val l: Int = hexChars[(it and 0x0F)].code
+    (h or l)
+}
+
+// Custom implementation of ByteArray.toHexString until stdlib stabilizes
+private fun ByteArray.toHexString(): String {
+    val result = CharArray(this.size*2);
+    var i = 0;
+    for (byte in this) {
+        val hx = HEX_LOOKUP_TABLE[byte.toInt() and 0xFF]
+        result[i]   = (hx shr 8).toChar()
+        result[i+1] = (hx and 0xff).toChar()
+        i+=2
+    }
+    return result.concatToString()
+}
 
 fun bytesToString(bytes: ByteArray): String {
-    val stringBuilder = StringBuilder(bytes.size)
-    for (byte in bytes) {
-        // byte to hex string
-        stringBuilder.append(String.format("%02X ", byte))
-    }
-    return stringBuilder.toString()
+    return bytes.toHexString()
 }
 
 fun stringToBytes(value: String): ByteArray {

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Conversion.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Conversion.kt
@@ -2,7 +2,7 @@ package com.capacitorjs.community.plugins.bluetoothle
 
 // Create a LUT for high performance ByteArray conversion
 val HEX_LOOKUP_TABLE = IntArray(256) {
-    val hexChars = "0123456789abcdef"
+    val hexChars = "0123456789ABCDEF"
     val h: Int = (hexChars[(it shr 4)].code shl 8)
     val l: Int = hexChars[(it and 0x0F)].code
     (h or l)
@@ -10,12 +10,12 @@ val HEX_LOOKUP_TABLE = IntArray(256) {
 
 // Custom implementation of ByteArray.toHexString until stdlib stabilizes
 private fun ByteArray.toHexString(): String {
-    val result = CharArray(this.size*2);
+    val result = CharArray(this.size * 2);
     var i = 0;
     for (byte in this) {
         val hx = HEX_LOOKUP_TABLE[byte.toInt() and 0xFF]
         result[i]   = (hx shr 8).toChar()
-        result[i+1] = (hx and 0xff).toChar()
+        result[i+1] = (hx and 0xFF).toChar()
         i+=2
     }
     return result.concatToString()

--- a/android/src/test/java/com/capacitorjs/community/plugins/bluetoothle/ConversionKtTest.kt
+++ b/android/src/test/java/com/capacitorjs/community/plugins/bluetoothle/ConversionKtTest.kt
@@ -9,7 +9,7 @@ class ConversionKtTest : TestCase() {
     fun testBytesToString() {
         val input = byteArrayOfInts(0xA1, 0x2E, 0x38, 0xD4, 0x89, 0xC3)
         val output = bytesToString(input)
-        assertEquals("A1 2E 38 D4 89 C3 ", output)
+        assertEquals("A12E38D489C3", output)
     }
 
     fun testEmptyBytesToString() {

--- a/ios/Plugin/Conversion.swift
+++ b/ios/Plugin/Conversion.swift
@@ -15,12 +15,23 @@ func descriptorValueToString(_ value: Any) -> String {
     return ""
 }
 
-func dataToString(_ data: Data) -> String {
-    var valueString = ""
-    for byte in data {
-        valueString += String(format: "%02hhx ", byte)
+extension Data {
+    func toHexString() -> String {
+        let hexChars = Array("0123456789abcdef".utf8)
+        return String(unsafeUninitializedCapacity: self.count*2) { (ptr) ->Int in
+            var s = ptr.baseAddress!
+            for byte in self {
+                s[0] = hexChars[Int(byte >> 4)]
+                s[1] = hexChars[Int(byte & 0xF)]
+                s += 2
+            }
+            return 2 * self.count
+        }
     }
-    return valueString
+}
+
+func dataToString(_ data: Data) -> String {
+    return data.toHexString()
 }
 
 func stringToData(_ dataString: String) -> Data {

--- a/ios/Plugin/Conversion.swift
+++ b/ios/Plugin/Conversion.swift
@@ -34,9 +34,9 @@ extension Data {
             result.reserveCapacity(self.count * 2)
             for byte in self {
                 let h = Int(byte >> 4)
-                let l = Int(byte & 0x0F)
-                result.append(hexChars[h])
-                result.append(hexChars[l])
+                let l = Int(byte & 0xF)
+                result.append(Character(UnicodeScalar(hexChars[h])))
+                result.append(Character(UnicodeScalar(hexChars[l])))
             }
             return result
         }

--- a/ios/Plugin/Conversion.swift
+++ b/ios/Plugin/Conversion.swift
@@ -19,12 +19,12 @@ extension Data {
     func toHexString() -> String {
         let hexChars = Array("0123456789abcdef".utf8)
         if #available(iOS 14, *) {
-            return String(unsafeUninitializedCapacity: self.count*2) { (ptr) ->Int in
-                var s = ptr.baseAddress!
+            return String(unsafeUninitializedCapacity: self.count*2) { (ptr) -> Int in
+                var strp = ptr.baseAddress!
                 for byte in self {
-                    s[0] = hexChars[Int(byte >> 4)]
-                    s[1] = hexChars[Int(byte & 0xF)]
-                    s += 2
+                    strp[0] = hexChars[Int(byte >> 4)]
+                    strp[1] = hexChars[Int(byte & 0xF)]
+                    strp += 2
                 }
                 return 2 * self.count
             }
@@ -33,10 +33,10 @@ extension Data {
             var result = ""
             result.reserveCapacity(self.count * 2)
             for byte in self {
-                let h = Int(byte >> 4)
-                let l = Int(byte & 0xF)
-                result.append(Character(UnicodeScalar(hexChars[h])))
-                result.append(Character(UnicodeScalar(hexChars[l])))
+                let high = Int(byte >> 4)
+                let low  = Int(byte & 0xF)
+                result.append(Character(UnicodeScalar(hexChars[high])))
+                result.append(Character(UnicodeScalar(hexChars[low])))
             }
             return result
         }

--- a/ios/Plugin/Conversion.swift
+++ b/ios/Plugin/Conversion.swift
@@ -18,14 +18,27 @@ func descriptorValueToString(_ value: Any) -> String {
 extension Data {
     func toHexString() -> String {
         let hexChars = Array("0123456789abcdef".utf8)
-        return String(unsafeUninitializedCapacity: self.count*2) { (ptr) ->Int in
-            var s = ptr.baseAddress!
-            for byte in self {
-                s[0] = hexChars[Int(byte >> 4)]
-                s[1] = hexChars[Int(byte & 0xF)]
-                s += 2
+        if #available(iOS 14, *) {
+            return String(unsafeUninitializedCapacity: self.count*2) { (ptr) ->Int in
+                var s = ptr.baseAddress!
+                for byte in self {
+                    s[0] = hexChars[Int(byte >> 4)]
+                    s[1] = hexChars[Int(byte & 0xF)]
+                    s += 2
+                }
+                return 2 * self.count
             }
-            return 2 * self.count
+        } else {
+            // Fallback implementation for iOS < 14, a bit slower
+            var result = ""
+            result.reserveCapacity(self.count * 2)
+            for byte in self {
+                let h = Int(byte >> 4)
+                let l = Int(byte & 0x0F)
+                result.append(hexChars[h])
+                result.append(hexChars[l])
+            }
+            return result
         }
     }
 }

--- a/ios/PluginTests/ConversionTests.swift
+++ b/ios/PluginTests/ConversionTests.swift
@@ -8,7 +8,7 @@ class ConversionTests: XCTestCase {
     func testDataToString() throws {
         let input = Data([0xA1, 0x2E, 0x38, 0xD4, 0x89, 0xC3])
         let output = dataToString(input)
-        XCTAssertEqual(output, "a1 2e 38 d4 89 c3 ")
+        XCTAssertEqual(output, "a12e38d489c3")
     }
 
     func testStringToData() throws {
@@ -44,11 +44,11 @@ class ConversionTests: XCTestCase {
     }
 
     func testDescriptorValueToString() throws {
-        XCTAssertEqual(descriptorValueToString("Hello"), "48 65 6c 6c 6f ")
-        XCTAssertEqual(descriptorValueToString(Data([0, 5, 255])), "00 05 ff ")
-        XCTAssertEqual(descriptorValueToString(UInt16(258)), "02 01 ")
-        XCTAssertEqual(descriptorValueToString(UInt16(1)), "01 00 ")
-        XCTAssertEqual(descriptorValueToString(NSNumber(1)), "01 00 ")
+        XCTAssertEqual(descriptorValueToString("Hello"), "48656c6c6f")
+        XCTAssertEqual(descriptorValueToString(Data([0, 5, 255])), "0005ff")
+        XCTAssertEqual(descriptorValueToString(UInt16(258)), "0201")
+        XCTAssertEqual(descriptorValueToString(UInt16(1)), "0100")
+        XCTAssertEqual(descriptorValueToString(NSNumber(1)), "0100")
         XCTAssertEqual(descriptorValueToString(0), "")
     }
 

--- a/src/conversion.spec.ts
+++ b/src/conversion.spec.ts
@@ -113,7 +113,7 @@ describe('hexStringToDataView', () => {
     expect(result.getUint8(1)).toEqual(5);
     expect(result.getUint8(2)).toEqual(200);
   });
-  
+
   it('should work without spaces', () => {
     const value = '0005C8';
     const result = hexStringToDataView(value);

--- a/src/conversion.spec.ts
+++ b/src/conversion.spec.ts
@@ -113,6 +113,15 @@ describe('hexStringToDataView', () => {
     expect(result.getUint8(1)).toEqual(5);
     expect(result.getUint8(2)).toEqual(200);
   });
+  
+  it('should work without spaces', () => {
+    const value = '0005C8';
+    const result = hexStringToDataView(value);
+    expect(result.byteLength).toEqual(3);
+    expect(result.getUint8(0)).toEqual(0);
+    expect(result.getUint8(1)).toEqual(5);
+    expect(result.getUint8(2)).toEqual(200);
+  });
 
   it('should convert an empty hex string to a DataView', () => {
     const value = '';

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -43,15 +43,18 @@ export function numberToUUID(value: number): string {
  */
 export function hexStringToDataView(hex: string): DataView {
   const bin = [];
-  let i, c, isEmpty = 1, buffer = 0;
-  for(i = 0; i < hex.length; i++){
-      c = hex.charCodeAt(i);
-      if(c > 47 && c < 58 || c > 64 && c < 71 || c > 96 && c < 103){
-          buffer = buffer << 4 ^ (c > 64 ? c + 9 : c) & 15;
-          if((isEmpty ^= 1)){
-              bin.push(buffer & 0xff);
-          }
+  let i,
+    c,
+    isEmpty = 1,
+    buffer = 0;
+  for (i = 0; i < hex.length; i++) {
+    c = hex.charCodeAt(i);
+    if ((c > 47 && c < 58) || (c > 64 && c < 71) || (c > 96 && c < 103)) {
+      buffer = (buffer << 4) ^ ((c > 64 ? c + 9 : c) & 15);
+      if ((isEmpty ^= 1)) {
+        bin.push(buffer & 0xff);
       }
+    }
   }
   return numbersToDataView(bin);
 }

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -42,12 +42,13 @@ export function numberToUUID(value: number): string {
  * @return DataView of raw bytes
  */
 export function hexStringToDataView(hex: string): DataView {
-  var bin = [], i, c, isEmpty = 1, buffer = 0;
+  const bin = [];
+  let i, c, isEmpty = 1, buffer = 0;
   for(i = 0; i < hex.length; i++){
       c = hex.charCodeAt(i);
       if(c > 47 && c < 58 || c > 64 && c < 71 || c > 96 && c < 103){
           buffer = buffer << 4 ^ (c > 64 ? c + 9 : c) & 15;
-          if(isEmpty ^= 1){
+          if((isEmpty ^= 1)){
               bin.push(buffer & 0xff);
           }
       }

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -35,13 +35,24 @@ export function numberToUUID(value: number): string {
   return `0000${value.toString(16).padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
 }
 
-export function hexStringToDataView(value: string): DataView {
-  const numbers: number[] = value
-    .trim()
-    .split(' ')
-    .filter((e) => e !== '')
-    .map((s) => parseInt(s, 16));
-  return numbersToDataView(numbers);
+/**
+ * Convert a string of hex into a DataView of raw bytes.
+ * Note: characters other than [0-9a-fA-F] are ignored
+ * @param hex string of values, e.g. "00 01 02" or "000102"
+ * @return DataView of raw bytes
+ */
+export function hexStringToDataView(hex: string): DataView {
+  var bin = [], i, c, isEmpty = 1, buffer = 0;
+  for(i = 0; i < hex.length; i++){
+      c = hex.charCodeAt(i);
+      if(c > 47 && c < 58 || c > 64 && c < 71 || c > 96 && c < 103){
+          buffer = buffer << 4 ^ (c > 64 ? c + 9 : c) & 15;
+          if(isEmpty ^= 1){
+              bin.push(buffer & 0xff);
+          }
+      }
+  }
+  return numbersToDataView(bin);
 }
 
 export function dataViewToHexString(value: DataView): string {


### PR DESCRIPTION
Per #698 I found the performance of the plugin to be a problem when moving data through a notification characteristic as fast as possible. 

This PR is focused on that use-case; high-throughput data transfer from peripheral _to_ the central. There may be additional performance gains to squeeze from the reverse path, however I haven't tested that case yet and suspect it is not as significant of an issue. 

I would appreciate extra scrutiny on the optimized Swift conversion function, as I could only test using the windows swift toolchain on my PC. The TypeScript side passes the existing conversion spec tests and the Kotlin side has been tested running on my Pixel 8 Pro passing data from an nRF devkit (the nature of this specific app requires the egressed data to contain a SHA-256 hash which is checked by the central so I am very confident data integrity is being maintained there).

I ran a profiling session moving 512KB of data from this implementation and recorded a wall time of only 124.61ms to perform the byte->hexstring conversion:
![image](https://github.com/user-attachments/assets/477e2eb2-bc7c-4a33-b143-72979d3a58f8)

Appreciative of any feedback or suggested improvements necessary to land this. 👍 