### PR TITLE
Add method getBondedDevices on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Below is an index of all the methods available.
 - [`requestLEScan(...)`](#requestlescan)
 - [`stopLEScan()`](#stoplescan)
 - [`getDevices(...)`](#getdevices)
+- [`getBondedDevices()`](#getbondeddevices)
 - [`getConnectedDevices(...)`](#getconnecteddevices)
 - [`connect(...)`](#connect)
 - [`createBond(...)`](#createbond)
@@ -588,13 +589,27 @@ On Android, you can directly connect to the device with the deviceId.
 
 ---
 
+### getBondedDevices()
+
+```typescript
+getBondedDevices() => Promise<BleDevice[]>
+```
+
+Get a list of currently connected devices.
+Only available on **Android**.
+[getBondedDevices](<https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()>) on Android
+
+**Returns:** <code>Promise&lt;BleDevice[]&gt;</code>
+
+---
+
 ### getConnectedDevices(...)
 
 ```typescript
 getConnectedDevices(services: string[]) => Promise<BleDevice[]>
 ```
 
-Get a list of currently connected devices.
+Get a list of currently bonded devices.
 Uses [retrieveConnectedPeripherals](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals) on iOS,
 [getConnectedDevices](<https://developer.android.com/reference/android/bluetooth/BluetoothManager#getConnectedDevices(int)>) on Android
 and [getDevices](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/getDevices) on web.

--- a/README.md
+++ b/README.md
@@ -595,9 +595,9 @@ On Android, you can directly connect to the device with the deviceId.
 getBondedDevices() => Promise<BleDevice[]>
 ```
 
-Get a list of currently connected devices.
+Get a list of currently bonded devices.
 Only available on **Android**.
-[getBondedDevices](<https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()>) on Android
+Uses [getBondedDevices](<https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()>) on Android
 
 **Returns:** <code>Promise&lt;BleDevice[]&gt;</code>
 
@@ -609,7 +609,7 @@ Only available on **Android**.
 getConnectedDevices(services: string[]) => Promise<BleDevice[]>
 ```
 
-Get a list of currently bonded devices.
+Get a list of currently connected devices.
 Uses [retrieveConnectedPeripherals](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals) on iOS,
 [getConnectedDevices](<https://developer.android.com/reference/android/bluetooth/BluetoothManager#getConnectedDevices(int)>) on Android
 and [getDevices](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/getDevices) on web.

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -435,6 +435,30 @@ class BluetoothLe : Plugin() {
     }
 
     @PluginMethod
+    fun getBondedDevices(call: PluginCall) {
+        assertBluetoothAdapter(call) ?: return
+
+        val bluetoothManager = activity.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        val bluetoothAdapter = bluetoothManager.adapter
+
+        if (bluetoothAdapter == null) {
+            call.reject("Bluetooth is not supported on this device")
+            return
+        }
+
+        val bondedDevices = bluetoothAdapter.bondedDevices
+        val bleDevices = JSArray()
+
+        bondedDevices.forEach { device ->
+            bleDevices.put(getBleDevice(device))
+        }
+
+        val result = JSObject()
+        result.put("devices", bleDevices)
+        call.resolve(result)
+    }
+
+    @PluginMethod
     fun connect(call: PluginCall) {
         val device = getOrCreateDevice(call) ?: return
         val timeout = call.getFloat("timeout", CONNECTION_TIMEOUT)!!.toLong()

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -25,6 +25,7 @@ CAP_PLUGIN(BluetoothLe, "BluetoothLe",
            CAP_PLUGIN_METHOD(connect, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(createBond, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isBonded, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getBondedDevices, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(disconnect, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getServices, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getMtu, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -248,6 +248,10 @@ public class BluetoothLe: CAPPlugin {
         call.unavailable("isBonded is not available on iOS.")
     }
 
+    @objc func getBondedDevices(_ call: CAPPluginCall) {
+        call.unavailable("getBondedDevices is not available on iOS.")
+    }
+
     @objc func disconnect(_ call: CAPPluginCall) {
         guard self.getDeviceManager(call) != nil else { return }
         guard let device = self.getDevice(call, checkConnection: false) else { return }

--- a/src/bleClient.spec.ts
+++ b/src/bleClient.spec.ts
@@ -35,6 +35,9 @@ jest.mock('./plugin', () => {
     getConnectedDevices: jest.fn(() => {
       return Promise.resolve({ devices: [] });
     }),
+    getBondeddDevices: jest.fn(() => {
+      return Promise.resolve({ devices: [] });
+    }),
     connect: jest.fn(),
     createBond: jest.fn(),
     isBonded: jest.fn(),

--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -130,14 +130,14 @@ export interface BleClientInterface {
   getDevices(deviceIds: string[]): Promise<BleDevice[]>;
 
   /**
-   * Get a list of currently connected devices.
+   * Get a list of currently bonded devices.
    * Only available on **Android**.
-   * [getBondedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()) on Android
+   * Uses [getBondedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()) on Android
    */
   getBondedDevices(): Promise<BleDevice[]>;
 
   /**
-   * Get a list of currently bonded devices.
+   * Get a list of currently connected devices.
    * Uses [retrieveConnectedPeripherals](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals) on iOS,
    * [getConnectedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothManager#getConnectedDevices(int)) on Android
    * and [getDevices](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/getDevices) on web.

--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -131,6 +131,13 @@ export interface BleClientInterface {
 
   /**
    * Get a list of currently connected devices.
+   * Only available on **Android**.
+   * [getBondedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getBondedDevices()) on Android
+   */
+  getBondedDevices(): Promise<BleDevice[]>;
+
+  /**
+   * Get a list of currently bonded devices.
    * Uses [retrieveConnectedPeripherals](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1518924-retrieveconnectedperipherals) on iOS,
    * [getConnectedDevices](https://developer.android.com/reference/android/bluetooth/BluetoothManager#getConnectedDevices(int)) on Android
    * and [getDevices](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/getDevices) on web.
@@ -456,6 +463,13 @@ class BleClientClass implements BleClientInterface {
     services = services.map(parseUUID);
     return this.queue(async () => {
       const result = await BluetoothLe.getConnectedDevices({ services });
+      return result.devices;
+    });
+  }
+
+  async getBondedDevices(): Promise<BleDevice[]> {
+    return this.queue(async () => {
+      const result = await BluetoothLe.getBondedDevices();
       return result.devices;
     });
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -289,6 +289,7 @@ export interface BluetoothLePlugin {
   stopLEScan(): Promise<void>;
   getDevices(options: GetDevicesOptions): Promise<GetDevicesResult>;
   getConnectedDevices(options: GetConnectedDevicesOptions): Promise<GetDevicesResult>;
+  getBondedDevices(): Promise<GetDevicesResult>;
   addListener(
     eventName: 'onEnabledChanged',
     listenerFunc: (result: BooleanResult) => void

--- a/src/web.ts
+++ b/src/web.ts
@@ -174,6 +174,10 @@ export class BluetoothLeWeb extends WebPlugin implements BluetoothLePlugin {
     return { devices: bleDevices };
   }
 
+  async getBondedDevices(): Promise<GetDevicesResult> {
+    return {} as Promise<GetDevicesResult>;
+  }
+
   async connect(options: DeviceIdOptions & TimeoutOptions): Promise<void> {
     const device = this.getDeviceFromMap(options.deviceId);
     device.removeEventListener('gattserverdisconnected', this.onDisconnectedCallback);


### PR DESCRIPTION
Related to #714 

Added getBondedDevices method to retrieve the list of bonded devices as getConnectedDevices on some Android devices does not return them