### PR TITLE
fix: remove callback from map before invocation

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
@@ -675,8 +675,9 @@ class Device(
         if (callbackMap.containsKey(key)) {
             Logger.debug(TAG, "resolve: $key $value")
             timeoutQueue.popFirstMatch { it.key == key }?.handler?.removeCallbacksAndMessages(null)
-            callbackMap[key]?.invoke(CallbackResponse(true, value))
+            val callback = callbackMap[key]
             callbackMap.remove(key)
+            callback?.invoke(CallbackResponse(true, value))
         }
     }
 
@@ -684,8 +685,9 @@ class Device(
         if (callbackMap.containsKey(key)) {
             Logger.debug(TAG, "reject: $key $value")
             timeoutQueue.popFirstMatch { it.key == key }?.handler?.removeCallbacksAndMessages(null)
-            callbackMap[key]?.invoke(CallbackResponse(false, value))
+            val callback = callbackMap[key]
             callbackMap.remove(key)
+            callback?.invoke(CallbackResponse(false, value))
         }
     }
 


### PR DESCRIPTION
Prior to invoking the callback, remove it from the callback map to avoid a rare race condition (see #751). 

In certain timing-sensitive scenarios, invoking the callback before removing it allows a new command to be issued while the old callback is still registered. When the second command resolves, its callback lookup fails (since the first callback was only removed afterward), causing write commands to hang indefinitely until the library is reset.

This change ensures that callbacks are unregistered immediately before they’re called, preventing the lookup failure and the resulting deadlock.