### PR TITLE
fix(filters): restore filtering only with name functionality

### DIFF
--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -874,6 +874,13 @@ class BluetoothLe : Plugin() {
                     filters.add(filterBuilder.build())
                 }
             }
+            // Create filters when providing only name
+            if (name != null && filters.isEmpty()) {
+                val filterBuilder = ScanFilter.Builder()
+                filterBuilder.setDeviceName(name)
+                filters.add(filterBuilder.build())
+            }
+
             return filters;
         } catch (e: IllegalArgumentException) {
             call.reject("Invalid UUID or Manufacturer data provided.")


### PR DESCRIPTION
Fixes #762

Essentially restores only name filtering after it was removed in the 7.0.0 -> 7.1.0 transition