### PR TITLE
feat: add timeout for notifications and detect aborted pairing on android (#765)

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ Write a value to a descriptor.
 ### startNotifications(...)
 
 ```typescript
-startNotifications(deviceId: string, service: string, characteristic: string, callback: (value: DataView) => void) => Promise<void>
+startNotifications(deviceId: string, service: string, characteristic: string, callback: (value: DataView) => void, options?: TimeoutOptions | undefined) => Promise<void>
 ```
 
 Start listening to changes of the value of a characteristic.
@@ -881,6 +881,7 @@ For an example, see [usage](#usage).
 | **`service`**        | <code>string</code>                                               | UUID of the service (see [UUID format](#uuid-format))                                                          |
 | **`characteristic`** | <code>string</code>                                               | UUID of the characteristic (see [UUID format](#uuid-format))                                                   |
 | **`callback`**       | <code>(value: <a href="#dataview">DataView</a>) =&gt; void</code> | Callback function to use when the value of the characteristic changes                                          |
+| **`options`**        | <code><a href="#timeoutoptions">TimeoutOptions</a></code>         | Options for plugin call. Timeout not supported on **web**.                                                     |
 
 ---
 

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -757,6 +757,7 @@ class BluetoothLe : Plugin() {
     fun startNotifications(call: PluginCall) {
         val device = getDevice(call) ?: return
         val characteristic = getCharacteristic(call) ?: return
+        val timeout = call.getFloat("timeout", DEFAULT_TIMEOUT)!!.toLong()
         device.setNotifications(characteristic.first, characteristic.second, true, { response ->
             run {
                 val key =
@@ -769,7 +770,7 @@ class BluetoothLe : Plugin() {
                     Logger.error(TAG, "Error in notifyListeners: ${e.localizedMessage}", e)
                 }
             }
-        }, { response ->
+        }, timeout, { response ->
             run {
                 if (response.success) {
                     call.resolve()
@@ -784,8 +785,9 @@ class BluetoothLe : Plugin() {
     fun stopNotifications(call: PluginCall) {
         val device = getDevice(call) ?: return
         val characteristic = getCharacteristic(call) ?: return
+        val timeout = call.getFloat("timeout", DEFAULT_TIMEOUT)!!.toLong()
         device.setNotifications(
-            characteristic.first, characteristic.second, false, null
+            characteristic.first, characteristic.second, false, null, timeout
         ) { response ->
             run {
                 if (response.success) {

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
@@ -68,6 +68,7 @@ class Device(
     private var device: BluetoothDevice = bluetoothAdapter.getRemoteDevice(address)
     private var bluetoothGatt: BluetoothGatt? = null
     private var callbackMap = HashMap<String, ((CallbackResponse) -> Unit)>()
+    private val bondReceiverMap = HashMap<String, BroadcastReceiver>()
     private val timeoutQueue = ConcurrentLinkedQueue<TimeoutHandler>()
     private var bondStateReceiver: BroadcastReceiver? = null
     private var currentMtu = -1
@@ -280,6 +281,9 @@ class Device(
             super.onDescriptorWrite(gatt, descriptor, status)
             val key =
                 "writeDescriptor|${descriptor.characteristic.service.uuid}|${descriptor.characteristic.uuid}|${descriptor.uuid}"
+            bondReceiverMap.remove(key)?.let {
+                context.unregisterReceiver(it)
+            }
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 resolve(key, "Descriptor successfully written.")
             } else {
@@ -586,9 +590,30 @@ class Device(
             BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
         }
 
+        val bondReceiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context, intent: Intent) {
+                if (intent.action == BluetoothDevice.ACTION_BOND_STATE_CHANGED) {
+                    val prev = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, -1)
+                    val state = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, -1)
+                    if (prev == BluetoothDevice.BOND_BONDING && state == BluetoothDevice.BOND_NONE) {
+                        ctx.unregisterReceiver(this)
+                        reject(key, "Pairing request was cancelled by the user.")
+                    }
+                }
+            }
+        }
+        bondReceiverMap[key] = bondReceiver
+        context.registerReceiver(
+            bondReceiver,
+            IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED)
+        )
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val statusCode = bluetoothGatt?.writeDescriptor(descriptor, value)
             if (statusCode != BluetoothStatusCodes.SUCCESS) {
+                bondReceiverMap.remove(key)?.let {
+                    context.unregisterReceiver(it)
+                }
                 reject(key, "Setting notification failed with status code $statusCode.")
                 return
             }
@@ -596,6 +621,9 @@ class Device(
             descriptor.value = value
             val resultDesc = bluetoothGatt?.writeDescriptor(descriptor)
             if (resultDesc != true) {
+                bondReceiverMap.remove(key)?.let {
+                    context.unregisterReceiver(it)
+                }
                 reject(key, "Setting notification failed.")
                 return
             }

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/Device.kt
@@ -546,6 +546,7 @@ class Device(
         characteristicUUID: UUID,
         enable: Boolean,
         notifyCallback: ((CallbackResponse) -> Unit)?,
+        timeout: Long,
         callback: (CallbackResponse) -> Unit,
     ) {
         val key = "writeDescriptor|$serviceUUID|$characteristicUUID|$CLIENT_CHARACTERISTIC_CONFIG"
@@ -600,6 +601,7 @@ class Device(
             }
 
         }
+        setTimeout(key, "Set notifications timeout.", timeout)
         // wait for onDescriptorWrite
     }
 

--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -295,12 +295,14 @@ export interface BleClientInterface {
    * @param service UUID of the service (see [UUID format](#uuid-format))
    * @param characteristic UUID of the characteristic (see [UUID format](#uuid-format))
    * @param callback Callback function to use when the value of the characteristic changes
+   * @param options Options for plugin call. Timeout not supported on **web**.
    */
   startNotifications(
     deviceId: string,
     service: string,
     characteristic: string,
     callback: (value: DataView) => void,
+    options?: TimeoutOptions,
   ): Promise<void>;
 
   /**
@@ -674,6 +676,7 @@ class BleClientClass implements BleClientInterface {
     service: string,
     characteristic: string,
     callback: (value: DataView) => void,
+    options?: TimeoutOptions,
   ): Promise<void> {
     service = parseUUID(service);
     characteristic = parseUUID(characteristic);
@@ -688,6 +691,7 @@ class BleClientClass implements BleClientInterface {
         deviceId,
         service,
         characteristic,
+        ...options,
       });
     });
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -337,6 +337,6 @@ export interface BluetoothLePlugin {
   writeWithoutResponse(options: WriteOptions & TimeoutOptions): Promise<void>;
   readDescriptor(options: ReadDescriptorOptions & TimeoutOptions): Promise<ReadResult>;
   writeDescriptor(options: WriteDescriptorOptions & TimeoutOptions): Promise<void>;
-  startNotifications(options: ReadOptions): Promise<void>;
+  startNotifications(options: ReadOptions & TimeoutOptions): Promise<void>;
   stopNotifications(options: ReadOptions): Promise<void>;
 }


### PR DESCRIPTION
Previously, iOS applied an internal timeout to the `startNotifications` command, while Android did not. This change:

- Standardizes timeout behavior across both platforms
- Exposes an optional `timeout` parameter for callers to customize as needed
- Maintains backward compatibility by keeping the parameter optional


And on Android, cancelling the OS pairing prompt for a BLE device did not interrupt the `startNotifications` call, potentially causing hangs. This update:

- Detects when the user cancels bonding on Android
- Aborts the `startNotifications` call in response
- Aligns Android’s behaviour with the existing iOS implementation