### PR TITLE
feat: Add service data filtering support for BLE scanning across all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Below is an index of all the methods available.
 - [`startNotifications(...)`](#startnotifications)
 - [`stopNotifications(...)`](#stopnotifications)
 - [Interfaces](#interfaces)
+- [Type Aliases](#type-aliases)
 - [Enums](#enums)
 
 </docgen-index>
@@ -946,6 +947,77 @@ Stop listening to the changes of the value of a characteristic. For an example, 
 | **`dataPrefix`**        | <code><a href="#uint8array">Uint8Array</a></code> | Prefix to match in the manufacturer data field. On **Android** this field is mandatory.                                                                                                                     |
 | **`mask`**              | <code><a href="#uint8array">Uint8Array</a></code> | Set filter on partial manufacture data. For any bit in the mask, set it the 1 if it needs to match the one in manufacturer data, otherwise set it to 0. The `mask` must have the same length of dataPrefix. |
 
+#### Uint8Array
+
+A typed array of 8-bit unsigned integer values. The contents are initialized to 0. If the
+requested number of bytes could not be allocated an exception is raised.
+
+| Prop                    | Type                                                        | Description                                                                  |
+| ----------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **`BYTES_PER_ELEMENT`** | <code>number</code>                                         | The size in bytes of each element in the array.                              |
+| **`buffer`**            | <code><a href="#arraybufferlike">ArrayBufferLike</a></code> | The <a href="#arraybuffer">ArrayBuffer</a> instance referenced by the array. |
+| **`byteLength`**        | <code>number</code>                                         | The length in bytes of the array.                                            |
+| **`byteOffset`**        | <code>number</code>                                         | The offset in bytes of the array.                                            |
+| **`length`**            | <code>number</code>                                         | The length of the array.                                                     |
+
+| Method             | Signature                                                                                                                                                                      | Description                                                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **copyWithin**     | (target: number, start: number, end?: number \| undefined) =&gt; this                                                                                                          | Returns the this object after copying a section of the array identified by start and end to the same array starting at position target                                                                                                      |
+| **every**          | (predicate: (value: number, index: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; unknown, thisArg?: any) =&gt; boolean                                            | Determines whether all the members of an array satisfy the specified test.                                                                                                                                                                  |
+| **fill**           | (value: number, start?: number \| undefined, end?: number \| undefined) =&gt; this                                                                                             | Returns the this object after filling the section identified by start and end with value                                                                                                                                                    |
+| **filter**         | (predicate: (value: number, index: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; any, thisArg?: any) =&gt; <a href="#uint8array">Uint8Array</a>                   | Returns the elements of an array that meet the condition specified in a callback function.                                                                                                                                                  |
+| **find**           | (predicate: (value: number, index: number, obj: <a href="#uint8array">Uint8Array</a>) =&gt; boolean, thisArg?: any) =&gt; number \| undefined                                  | Returns the value of the first element in the array where predicate is true, and undefined otherwise.                                                                                                                                       |
+| **findIndex**      | (predicate: (value: number, index: number, obj: <a href="#uint8array">Uint8Array</a>) =&gt; boolean, thisArg?: any) =&gt; number                                               | Returns the index of the first element in the array where predicate is true, and -1 otherwise.                                                                                                                                              |
+| **forEach**        | (callbackfn: (value: number, index: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; void, thisArg?: any) =&gt; void                                                 | Performs the specified action for each element in an array.                                                                                                                                                                                 |
+| **indexOf**        | (searchElement: number, fromIndex?: number \| undefined) =&gt; number                                                                                                          | Returns the index of the first occurrence of a value in an array.                                                                                                                                                                           |
+| **join**           | (separator?: string \| undefined) =&gt; string                                                                                                                                 | Adds all the elements of an array separated by the specified separator string.                                                                                                                                                              |
+| **lastIndexOf**    | (searchElement: number, fromIndex?: number \| undefined) =&gt; number                                                                                                          | Returns the index of the last occurrence of a value in an array.                                                                                                                                                                            |
+| **map**            | (callbackfn: (value: number, index: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; number, thisArg?: any) =&gt; <a href="#uint8array">Uint8Array</a>               | Calls a defined callback function on each element of an array, and returns an array that contains the results.                                                                                                                              |
+| **reduce**         | (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; number) =&gt; number                       | Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.                      |
+| **reduce**         | (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; number, initialValue: number) =&gt; number |                                                                                                                                                                                                                                             |
+| **reduce**         | &lt;U&gt;(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; U, initialValue: U) =&gt; U            | Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.                      |
+| **reduceRight**    | (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; number) =&gt; number                       | Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function. |
+| **reduceRight**    | (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; number, initialValue: number) =&gt; number |                                                                                                                                                                                                                                             |
+| **reduceRight**    | &lt;U&gt;(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; U, initialValue: U) =&gt; U            | Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function. |
+| **reverse**        | () =&gt; <a href="#uint8array">Uint8Array</a>                                                                                                                                  | Reverses the elements in an Array.                                                                                                                                                                                                          |
+| **set**            | (array: <a href="#arraylike">ArrayLike</a>&lt;number&gt;, offset?: number \| undefined) =&gt; void                                                                             | Sets a value or an array of values.                                                                                                                                                                                                         |
+| **slice**          | (start?: number \| undefined, end?: number \| undefined) =&gt; <a href="#uint8array">Uint8Array</a>                                                                            | Returns a section of an array.                                                                                                                                                                                                              |
+| **some**           | (predicate: (value: number, index: number, array: <a href="#uint8array">Uint8Array</a>) =&gt; unknown, thisArg?: any) =&gt; boolean                                            | Determines whether the specified callback function returns true for any element of an array.                                                                                                                                                |
+| **sort**           | (compareFn?: ((a: number, b: number) =&gt; number) \| undefined) =&gt; this                                                                                                    | Sorts an array.                                                                                                                                                                                                                             |
+| **subarray**       | (begin?: number \| undefined, end?: number \| undefined) =&gt; <a href="#uint8array">Uint8Array</a>                                                                            | Gets a new <a href="#uint8array">Uint8Array</a> view of the <a href="#arraybuffer">ArrayBuffer</a> store for this array, referencing the elements at begin, inclusive, up to end, exclusive.                                                |
+| **toLocaleString** | () =&gt; string                                                                                                                                                                | Converts a number to a string by using the current locale.                                                                                                                                                                                  |
+| **toString**       | () =&gt; string                                                                                                                                                                | Returns a string representation of an array.                                                                                                                                                                                                |
+| **valueOf**        | () =&gt; <a href="#uint8array">Uint8Array</a>                                                                                                                                  | Returns the primitive value of the specified object.                                                                                                                                                                                        |
+
+#### ArrayLike
+
+| Prop         | Type                |
+| ------------ | ------------------- |
+| **`length`** | <code>number</code> |
+
+#### ArrayBufferTypes
+
+Allowed <a href="#arraybuffer">ArrayBuffer</a> types for the buffer of an ArrayBufferView and related Typed Arrays.
+
+| Prop              | Type                                                |
+| ----------------- | --------------------------------------------------- |
+| **`ArrayBuffer`** | <code><a href="#arraybuffer">ArrayBuffer</a></code> |
+
+#### ArrayBuffer
+
+Represents a raw buffer of binary data, which is used to store data for the
+different typed arrays. ArrayBuffers cannot be read from or written to directly,
+but can be passed to a typed array or <a href="#dataview">DataView</a> Object to interpret the raw
+buffer as needed.
+
+| Prop             | Type                | Description                                                                     |
+| ---------------- | ------------------- | ------------------------------------------------------------------------------- |
+| **`byteLength`** | <code>number</code> | Read-only. The length of the <a href="#arraybuffer">ArrayBuffer</a> (in bytes). |
+
+| Method    | Signature                                                                               | Description                                                     |
+| --------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **slice** | (begin: number, end?: number \| undefined) =&gt; <a href="#arraybuffer">ArrayBuffer</a> | Returns a section of an <a href="#arraybuffer">ArrayBuffer</a>. |
+
 #### ScanResult
 
 | Prop                   | Type                                                              | Description                                                                                                                                                                                                                                                                                           |
@@ -985,21 +1057,6 @@ Stop listening to the changes of the value of a characteristic. For an example, 
 | **setUint8**   | (byteOffset: number, value: number) =&gt; void                                      | Stores an Uint8 value at the specified byte offset from the start of the view.                                                                                      |
 | **setUint16**  | (byteOffset: number, value: number, littleEndian?: boolean \| undefined) =&gt; void | Stores an Uint16 value at the specified byte offset from the start of the view.                                                                                     |
 | **setUint32**  | (byteOffset: number, value: number, littleEndian?: boolean \| undefined) =&gt; void | Stores an Uint32 value at the specified byte offset from the start of the view.                                                                                     |
-
-#### ArrayBuffer
-
-Represents a raw buffer of binary data, which is used to store data for the
-different typed arrays. ArrayBuffers cannot be read from or written to directly,
-but can be passed to a typed array or <a href="#dataview">DataView</a> Object to interpret the raw
-buffer as needed.
-
-| Prop             | Type                | Description                                                                     |
-| ---------------- | ------------------- | ------------------------------------------------------------------------------- |
-| **`byteLength`** | <code>number</code> | Read-only. The length of the <a href="#arraybuffer">ArrayBuffer</a> (in bytes). |
-
-| Method    | Signature                                                                               | Description                                                     |
-| --------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **slice** | (begin: number, end?: number \| undefined) =&gt; <a href="#arraybuffer">ArrayBuffer</a> | Returns a section of an <a href="#arraybuffer">ArrayBuffer</a>. |
 
 #### TimeoutOptions
 
@@ -1044,6 +1101,12 @@ buffer as needed.
 | Prop       | Type                |
 | ---------- | ------------------- |
 | **`uuid`** | <code>string</code> |
+
+### Type Aliases
+
+#### ArrayBufferLike
+
+<code>ArrayBufferTypes[keyof ArrayBufferTypes]</code>
 
 ### Enums
 

--- a/SERVICE_DATA_FILTERING.md
+++ b/SERVICE_DATA_FILTERING.md
@@ -1,0 +1,231 @@
+# Service Data Filtering Support
+
+This document explains how to use the new **Service Data Filtering** feature added to the Bluetooth LE plugin.
+
+## Overview
+
+The plugin now supports filtering BLE devices by **Service Data** in addition to the existing filters (service UUIDs, manufacturer data, device name, etc.).
+
+This is particularly useful for protocols like **OpenDroneID** that use service data for advertising specific information.
+
+## Usage
+
+### Basic Example: OpenDroneID
+
+To scan for OpenDroneID devices that advertise with service UUID `0000fffa-0000-1000-8000-00805f9b34fb` and service data prefix `0x0D`:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D]
+    }
+  ],
+  allowDuplicates: true
+});
+
+// Listen for scan results
+BluetoothLe.addListener('onScanResult', (result) => {
+  console.log('Found device:', result);
+});
+```
+
+### Service Data Filter Parameters
+
+The `serviceData` parameter accepts an array of filter objects with the following properties:
+
+```typescript
+interface ServiceDataFilter {
+  serviceUuid: string;        // Required: The service UUID (e.g., "0000fffa-0000-1000-8000-00805f9b34fb")
+  dataPrefix?: number[];      // Optional: Array of bytes that the service data must start with
+  mask?: number[];            // Optional: Bit mask to apply when matching dataPrefix
+}
+```
+
+### Examples
+
+#### 1. Filter by Service UUID Only
+
+Match any device advertising the specified service UUID:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb"
+    }
+  ]
+});
+```
+
+#### 2. Filter by Service UUID + Data Prefix
+
+Match devices with specific service data content:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D]
+    }
+  ]
+});
+```
+
+#### 3. Filter with Bit Mask
+
+Use a mask to match specific bits in the service data:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D, 0x00],
+      mask: [0xFF, 0xF0]  // Only compare first byte fully, and upper 4 bits of second byte
+    }
+  ]
+});
+```
+
+#### 4. Multiple Service Data Filters
+
+Scan for devices matching any of the specified service data filters:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D]
+    },
+    {
+      serviceUuid: "0000fff0-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x10]
+    }
+  ]
+});
+```
+
+#### 5. Combine with Other Filters
+
+You can combine service data filters with other filter types:
+
+```javascript
+await BluetoothLe.requestLEScan({
+  services: ["0000180a-0000-1000-8000-00805f9b34fb"],  // Service UUID filter
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D]
+    }
+  ],
+  namePrefix: "Drone",  // Device name prefix filter
+  allowDuplicates: true
+});
+```
+
+## Platform Support
+
+### Android
+- ✅ Full support via `ScanFilter.Builder().setServiceData()`
+- Uses `CBAdvertisementDataServiceDataKey` for filtering
+- Supports service UUID, data prefix, and bit mask
+
+### iOS
+- ✅ Full support via custom filtering logic
+- Uses `CBAdvertisementDataServiceDataKey` for filtering
+- Supports service UUID, data prefix, and bit mask
+
+## How It Works
+
+### Android Implementation
+
+The Android implementation adds service data filters to the scan filter list:
+
+```kotlin
+val filterBuilder = ScanFilter.Builder()
+
+if (dataPrefix != null && mask != null) {
+    filterBuilder.setServiceData(servicePuuid, dataPrefix, mask)
+} else if (dataPrefix != null) {
+    filterBuilder.setServiceData(servicePuuid, dataPrefix)
+} else {
+    filterBuilder.setServiceData(servicePuuid, byteArrayOf())
+}
+```
+
+### iOS Implementation
+
+The iOS implementation filters discovered devices by checking service data in advertisement data:
+
+```swift
+guard let serviceDataDict = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data] else {
+    return false
+}
+
+for filter in filters {
+    guard let serviceData = serviceDataDict[filter.serviceUuid] else {
+        continue
+    }
+    
+    // Match dataPrefix with optional mask
+    if let dataPrefix = filter.dataPrefix {
+        if let mask = filter.mask {
+            // Apply mask and compare
+        } else if serviceData.starts(with: dataPrefix) {
+            return true
+        }
+    }
+}
+```
+
+## Migration from Old Implementation
+
+### Before (OpenDroneID-specific method):
+
+```javascript
+// Had to use a separate method or hardcoded values
+await BluetoothLe.requestLEScanOpendroneId({
+  allowDuplicates: true
+});
+```
+
+### After (Unified method with service data):
+
+```javascript
+// Use the standard method with service data filter
+await BluetoothLe.requestLEScan({
+  serviceData: [
+    {
+      serviceUuid: "0000fffa-0000-1000-8000-00805f9b34fb",
+      dataPrefix: [0x0D]
+    }
+  ],
+  allowDuplicates: true
+});
+```
+
+## Benefits
+
+1. **Flexibility**: Filter by any service UUID and data pattern, not just hardcoded values
+2. **Unified API**: One method works for all scanning scenarios
+3. **Cross-platform**: Consistent behavior on both Android and iOS
+4. **Efficient**: Hardware-level filtering on Android, optimized filtering on iOS
+5. **Composable**: Combine with other filter types for precise device discovery
+
+## Notes
+
+- On Android, service data filtering is done at the hardware/OS level for efficiency
+- On iOS, service data filtering is done in software during the scan callback
+- The `dataPrefix` and `mask` arrays use the same format as `manufacturerData` filters
+- If no filters are specified, all devices are discovered (existing behavior)
+- Service data filters are combined with OR logic (any match passes)
+
+## See Also
+
+- [Manufacturer Data Filtering](README.md#manufacturer-data-filtering)
+- [Service UUID Filtering](README.md#service-uuid-filtering)
+- [OpenDroneID Protocol](https://github.com/opendroneid)

--- a/SERVICE_DATA_USAGE.md
+++ b/SERVICE_DATA_USAGE.md
@@ -256,9 +256,9 @@ async function scanForDrones() {
 
 | Feature | Android | iOS | Web |
 |---------|---------|-----|-----|
-| Service UUID filtering | ✅ Hardware | ✅ Software | ❌ |
-| Service data prefix | ✅ Hardware | ✅ Software | ❌ |
-| Service data mask | ✅ Hardware | ✅ Software | ❌ |
+| Service UUID filtering | ✅ Hardware | ✅ Software | ✅ Client-side |
+| Service data prefix | ✅ Hardware | ✅ Software | ✅ Client-side |
+| Service data mask | ✅ Hardware | ✅ Software | ✅ Client-side |
 
 ### Android
 - Uses `ScanFilter.Builder().setServiceData()`
@@ -271,8 +271,12 @@ async function scanForDrones() {
 - Supports all filter combinations
 
 ### Web
-- Web Bluetooth API does not support service data filtering
-- Falls back to service UUID filtering only
+- **Note:** Web Bluetooth API does not support service data in native scan filters
+- Service data filtering is done **client-side** in JavaScript
+- Filters are applied after receiving advertisement events
+- All devices are scanned, then filtered in the `onAdvertisementReceived` callback
+- Less efficient than native filtering, but functionally equivalent
+- Supports all filter combinations (serviceUuid, dataPrefix, mask)
 
 ## Key Differences from Manufacturer Data
 

--- a/SERVICE_DATA_USAGE.md
+++ b/SERVICE_DATA_USAGE.md
@@ -1,0 +1,351 @@
+# Service Data Filtering - Complete Usage Guide
+
+## Overview
+
+The Bluetooth LE plugin now supports **service data filtering** for both Android and iOS. Service data is data associated with a specific service UUID in BLE advertisement packets, commonly used by protocols like OpenDroneID.
+
+## TypeScript Definitions
+
+### `ServiceDataFilter` Interface
+
+```typescript
+export interface ServiceDataFilter {
+  /**
+   * Service UUID to filter by. The service data must be associated with this UUID.
+   * UUIDs have to be specified as 128 bit UUID strings,
+   * e.g. '0000fffa-0000-1000-8000-00805f9b34fb'
+   */
+  serviceUuid: string;
+
+  /**
+   * Prefix to match in the service data field.
+   * For example, OpenDroneID uses [0x0D] as the advertisement code.
+   */
+  dataPrefix?: Uint8Array;
+
+  /**
+   * Set filter on partial service data. For any bit in the mask, set it to 1 
+   * if it needs to match the one in service data, otherwise set it to 0.
+   * The `mask` must have the same length as dataPrefix.
+   */
+  mask?: Uint8Array;
+}
+```
+
+### Updated `RequestBleDeviceOptions`
+
+```typescript
+export interface RequestBleDeviceOptions {
+  services?: string[];
+  name?: string;
+  namePrefix?: string;
+  optionalServices?: string[];
+  allowDuplicates?: boolean;
+  scanMode?: ScanMode;
+  manufacturerData?: ManufacturerDataFilter[];
+  
+  /**
+   * Allow scanning for devices with specific service data.
+   * Service data is data associated with a specific service UUID in the advertisement packet.
+   * Useful for protocols like OpenDroneID.
+   */
+  serviceData?: ServiceDataFilter[];
+}
+```
+
+## Usage Examples
+
+### 1. Basic OpenDroneID Scanning
+
+Scan for OpenDroneID devices with service UUID and AD code `0x0D`:
+
+```typescript
+import { BleClient } from '@capacitor-community/bluetooth-le';
+
+await BleClient.initialize();
+
+await BleClient.requestLEScan(
+  {
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x0D])
+      }
+    ],
+    allowDuplicates: true
+  },
+  (result) => {
+    console.log('Found OpenDroneID device:', result);
+    console.log('Device ID:', result.device.deviceId);
+    console.log('RSSI:', result.rssi);
+    console.log('Service Data:', result.serviceData);
+  }
+);
+```
+
+### 2. Filter by Service UUID Only
+
+Match any device advertising the specified service UUID:
+
+```typescript
+await BleClient.requestLEScan(
+  {
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb'
+        // No dataPrefix = match any data for this service
+      }
+    ]
+  },
+  (result) => {
+    console.log('Device found:', result);
+  }
+);
+```
+
+### 3. Using Bit Mask for Pattern Matching
+
+Match specific bits in service data using a mask:
+
+```typescript
+await BleClient.requestLEScan(
+  {
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x0D, 0x00]),
+        mask: new Uint8Array([0xFF, 0xF0])  // Match first byte fully, upper 4 bits of second
+      }
+    ],
+    allowDuplicates: true
+  },
+  (result) => {
+    console.log('Matched with mask:', result);
+  }
+);
+```
+
+### 4. Multiple Service Data Filters
+
+Scan for devices matching ANY of the specified filters (OR logic):
+
+```typescript
+await BleClient.requestLEScan(
+  {
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x0D])
+      },
+      {
+        serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x10])
+      }
+    ]
+  },
+  (result) => {
+    console.log('Device matches one of the filters:', result);
+  }
+);
+```
+
+### 5. Combine All Filter Types
+
+Use service data filtering along with other filters:
+
+```typescript
+await BleClient.requestLEScan(
+  {
+    // Standard service UUID filter
+    services: ['0000180a-0000-1000-8000-00805f9b34fb'],
+    
+    // Service data filter
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x0D])
+      }
+    ],
+    
+    // Manufacturer data filter
+    manufacturerData: [
+      {
+        companyIdentifier: 0x004C,  // Apple
+        dataPrefix: new Uint8Array([0x02, 0x15])
+      }
+    ],
+    
+    // Name filters
+    name: 'MyDevice',
+    namePrefix: 'Drone',
+    
+    // Scan settings
+    allowDuplicates: true,
+    scanMode: ScanMode.SCAN_MODE_LOW_LATENCY
+  },
+  (result) => {
+    console.log('Device matches all filters:', result);
+  }
+);
+```
+
+### 6. Stop Scanning
+
+```typescript
+await BleClient.stopLEScan();
+```
+
+## OpenDroneID Specific Example
+
+Complete example for scanning OpenDroneID drones:
+
+```typescript
+import { BleClient, ScanMode } from '@capacitor-community/bluetooth-le';
+
+// OpenDroneID constants
+const OPENDRONEID_SERVICE_UUID = '0000fffa-0000-1000-8000-00805f9b34fb';
+const OPENDRONEID_AD_CODE = 0x0D;
+
+async function scanForDrones() {
+  try {
+    await BleClient.initialize();
+    
+    console.log('Starting OpenDroneID scan...');
+    
+    await BleClient.requestLEScan(
+      {
+        serviceData: [
+          {
+            serviceUuid: OPENDRONEID_SERVICE_UUID,
+            dataPrefix: new Uint8Array([OPENDRONEID_AD_CODE])
+          }
+        ],
+        allowDuplicates: true,
+        scanMode: ScanMode.SCAN_MODE_LOW_LATENCY
+      },
+      (result) => {
+        console.log('Drone detected!');
+        console.log('Device ID:', result.device.deviceId);
+        console.log('Device Name:', result.device.name);
+        console.log('RSSI:', result.rssi);
+        
+        // Parse OpenDroneID service data
+        if (result.serviceData) {
+          const serviceData = result.serviceData[OPENDRONEID_SERVICE_UUID];
+          if (serviceData) {
+            console.log('OpenDroneID Data:', serviceData);
+            // Process OpenDroneID message...
+          }
+        }
+      }
+    );
+    
+    // Stop after 30 seconds
+    setTimeout(async () => {
+      await BleClient.stopLEScan();
+      console.log('Scan stopped');
+    }, 30000);
+    
+  } catch (error) {
+    console.error('Error scanning:', error);
+  }
+}
+```
+
+## Platform Support
+
+| Feature | Android | iOS | Web |
+|---------|---------|-----|-----|
+| Service UUID filtering | ✅ Hardware | ✅ Software | ❌ |
+| Service data prefix | ✅ Hardware | ✅ Software | ❌ |
+| Service data mask | ✅ Hardware | ✅ Software | ❌ |
+
+### Android
+- Uses `ScanFilter.Builder().setServiceData()`
+- Hardware-level filtering for efficiency
+- Supports all filter combinations
+
+### iOS
+- Uses `CBAdvertisementDataServiceDataKey` for filtering
+- Software filtering in scan callback
+- Supports all filter combinations
+
+### Web
+- Web Bluetooth API does not support service data filtering
+- Falls back to service UUID filtering only
+
+## Key Differences from Manufacturer Data
+
+| Feature | Service Data | Manufacturer Data |
+|---------|-------------|------------------|
+| **Associated with** | Service UUID | Company Identifier |
+| **Use case** | Protocol-specific data (OpenDroneID) | Vendor-specific data (iBeacon) |
+| **Filter key** | `serviceUuid` (string) | `companyIdentifier` (number) |
+| **Data location** | Service data field in adv. packet | Manufacturer data field |
+
+## Migration Guide
+
+If you were using the old `requestLEScanOpendroneId` method:
+
+### Before:
+```typescript
+// Old hardcoded method (removed)
+await BluetoothLe.requestLEScanOpendroneId({ allowDuplicates: true });
+```
+
+### After:
+```typescript
+// New unified method with service data filter
+await BleClient.requestLEScan(
+  {
+    serviceData: [
+      {
+        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
+        dataPrefix: new Uint8Array([0x0D])
+      }
+    ],
+    allowDuplicates: true
+  },
+  (result) => {
+    // Handle scan result
+  }
+);
+```
+
+## Troubleshooting
+
+### No devices found
+
+1. Verify the service UUID is correct
+2. Check that the device is advertising service data (not just the service UUID)
+3. Try removing `dataPrefix` to match any service data
+4. Enable `allowDuplicates` to see repeated advertisements
+
+### TypeScript errors
+
+Make sure to import the types:
+
+```typescript
+import { 
+  BleClient, 
+  ServiceDataFilter, 
+  RequestBleDeviceOptions 
+} from '@capacitor-community/bluetooth-le';
+```
+
+### Platform-specific issues
+
+**Android:**
+- Requires location permissions for BLE scanning
+- Check that Bluetooth and location are enabled
+
+**iOS:**
+- Check that Bluetooth permission is granted
+- Service data filtering is done in software (may be less efficient than Android)
+
+## Related Documentation
+
+- [Manufacturer Data Filtering](./README.md#manufacturer-data-filtering)
+- [Service UUID Filtering](./README.md#service-uuid-filtering)
+- [OpenDroneID Specification](https://github.com/opendroneid/opendroneid-core-c)
+- [BLE Advertisement Packet Structure](https://www.bluetooth.com/specifications/assigned-numbers/)

--- a/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
+++ b/android/src/main/java/com/capacitorjs/community/plugins/bluetoothle/BluetoothLe.kt
@@ -812,6 +812,7 @@ class BluetoothLe : Plugin() {
 
         val services = (call.getArray("services", JSArray()) as JSArray).toList<String>()
         val manufacturerDataArray = call.getArray("manufacturerData", JSArray())
+        val serviceDataArray = call.getArray("serviceData", JSArray())
         val name = call.getString("name", null)
 
         try {
@@ -823,6 +824,57 @@ class BluetoothLe : Plugin() {
                     filter.setDeviceName(name)
                 }
                 filters.add(filter.build())
+            }
+
+            // Service Data Handling (for filtering by service data like OpenDroneID)
+            serviceDataArray?.let {
+                for (i in 0 until it.length()) {
+                    val serviceDataObject = it.getJSONObject(i)
+
+                    val serviceUuid = serviceDataObject.getString("serviceUuid")
+                    val servicePuuid = ParcelUuid.fromString(serviceUuid)
+
+                    val dataPrefix = if (serviceDataObject.has("dataPrefix")) {
+                        val dataPrefixObject = serviceDataObject.getJSONObject("dataPrefix")
+                        val byteLength = dataPrefixObject.length()
+
+                        ByteArray(byteLength).apply {
+                            for (idx in 0 until byteLength) {
+                                val key = idx.toString()
+                                this[idx] = (dataPrefixObject.getInt(key) and 0xFF).toByte()
+                            }
+                        }
+                    } else null
+
+                    val mask = if (serviceDataObject.has("mask")) {
+                        val maskObject = serviceDataObject.getJSONObject("mask")
+                        val byteLength = maskObject.length()
+
+                        ByteArray(byteLength).apply {
+                            for (idx in 0 until byteLength) {
+                                val key = idx.toString()
+                                this[idx] = (maskObject.getInt(key) and 0xFF).toByte()
+                            }
+                        }
+                    } else null
+
+                    val filterBuilder = ScanFilter.Builder()
+
+                    if (dataPrefix != null && mask != null) {
+                        filterBuilder.setServiceData(servicePuuid, dataPrefix, mask)
+                    } else if (dataPrefix != null) {
+                        filterBuilder.setServiceData(servicePuuid, dataPrefix)
+                    } else {
+                        // Set service data filter without data (just match the service UUID)
+                        filterBuilder.setServiceData(servicePuuid, byteArrayOf())
+                    }
+
+                    if (name != null) {
+                        filterBuilder.setDeviceName(name)
+                    }
+
+                    filters.add(filterBuilder.build())
+                }
             }
 
             // Manufacturer Data Handling (with optional parameters)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -13,6 +13,12 @@ struct ManufacturerDataFilter {
     let mask: Data?
 }
 
+struct ServiceDataFilter {
+    let serviceUuid: CBUUID
+    let dataPrefix: Data?
+    let mask: Data?
+}
+
 @objc(BluetoothLe)
 public class BluetoothLe: CAPPlugin {
     typealias BleDevice = [String: Any]
@@ -117,12 +123,14 @@ public class BluetoothLe: CAPPlugin {
         let name = call.getString("name")
         let namePrefix = call.getString("namePrefix")
         let manufacturerDataFilters = self.getManufacturerDataFilters(call)
+        let serviceDataFilters = self.getServiceDataFilters(call)
 
         deviceManager.startScanning(
             serviceUUIDs,
             name,
             namePrefix,
             manufacturerDataFilters,
+            serviceDataFilters,
             false,
             true,
             30,
@@ -151,12 +159,14 @@ public class BluetoothLe: CAPPlugin {
         let namePrefix = call.getString("namePrefix")
         let allowDuplicates = call.getBool("allowDuplicates", false)
         let manufacturerDataFilters = self.getManufacturerDataFilters(call)
+        let serviceDataFilters = self.getServiceDataFilters(call)
 
         deviceManager.startScanning(
             serviceUUIDs,
             name,
             namePrefix,
             manufacturerDataFilters,
+            serviceDataFilters,
             allowDuplicates,
             false,
             nil,
@@ -565,6 +575,44 @@ public class BluetoothLe: CAPPlugin {
         }
 
         return manufacturerDataFilters
+    }
+
+    private func getServiceDataFilters(_ call: CAPPluginCall) -> [ServiceDataFilter]? {
+        guard let serviceDataArray = call.getArray("serviceData") else {
+            return nil
+        }
+
+        var serviceDataFilters: [ServiceDataFilter] = []
+
+        for index in 0..<serviceDataArray.count {
+            guard let dataObject = serviceDataArray[index] as? JSObject,
+                  let serviceUuidString = dataObject["serviceUuid"] as? String else {
+                // Invalid or missing service UUID
+                return nil
+            }
+
+            let serviceUuid = CBUUID(string: serviceUuidString)
+
+            let dataPrefix: Data? = {
+                guard let prefixArray = dataObject["dataPrefix"] as? [Int] else { return nil }
+                return Data(prefixArray.map { UInt8($0 & 0xFF) })
+            }()
+
+            let mask: Data? = {
+                guard let maskArray = dataObject["mask"] as? [Int] else { return nil }
+                return Data(maskArray.map { UInt8($0 & 0xFF) })
+            }()
+
+            let serviceDataFilter = ServiceDataFilter(
+                serviceUuid: serviceUuid,
+                dataPrefix: dataPrefix,
+                mask: mask
+            )
+
+            serviceDataFilters.append(serviceDataFilter)
+        }
+
+        return serviceDataFilters
     }
 
     private func getDevice(_ call: CAPPluginCall, checkConnection: Bool = true) -> Device? {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -51,6 +51,12 @@ export interface RequestBleDeviceOptions {
    * https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#manufacturerdata
    */
   manufacturerData?: ManufacturerDataFilter[];
+  /**
+   * Allow scanning for devices with specific service data.
+   * Service data is data associated with a specific service UUID in the advertisement packet.
+   * Useful for protocols like OpenDroneID.
+   */
+  serviceData?: ServiceDataFilter[];
 }
 
 /**
@@ -110,6 +116,27 @@ export interface ManufacturerDataFilter {
   /**
    * Set filter on partial manufacture data. For any bit in the mask, set it the 1 if it needs to match the one in manufacturer data, otherwise set it to 0.
    * The `mask` must have the same length of dataPrefix.
+   */
+  mask?: Uint8Array;
+}
+
+export interface ServiceDataFilter {
+  /**
+   * Service UUID to filter by. The service data must be associated with this UUID.
+   * UUIDs have to be specified as 128 bit UUID strings,
+   * e.g. '0000fffa-0000-1000-8000-00805f9b34fb'
+   */
+  serviceUuid: string;
+
+  /**
+   * Prefix to match in the service data field.
+   * For example, OpenDroneID uses [0x0D] as the advertisement code.
+   */
+  dataPrefix?: Uint8Array;
+
+  /**
+   * Set filter on partial service data. For any bit in the mask, set it to 1 if it needs to match the one in service data, otherwise set it to 0.
+   * The `mask` must have the same length as dataPrefix.
    */
   mask?: Uint8Array;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "inlineSources": true,
-    "lib": ["dom", "es2017"],
+    "lib": ["dom", "es2018"],
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
@@ -14,7 +14,8 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "types": ["jest", "@types/web-bluetooth"]
   },
   "files": ["src/index.ts"]
 }


### PR DESCRIPTION
# Pull Request: Add Service Data Filtering Support

## Pull Request Title

```
feat: Add service data filtering support for BLE scanning across all platforms
```

## Pull Request Description

### 📋 Summary

Adds comprehensive service data filtering capability to `requestLEScan` and `requestDevice` methods, enabling filtering of BLE advertisements based on service-specific data payloads. This is particularly useful for protocols like OpenDroneID that use service data for device identification.

### 🎯 Motivation

Previously, the plugin only supported filtering by:
- Service UUIDs
- Device names
- Manufacturer data

Many BLE protocols (e.g., OpenDroneID) use **service data** fields in advertisement packets for identification and filtering. This PR adds native support for service data filtering across all platforms.

### ✨ Changes

#### **TypeScript/Web** (`src`)
- Added new `ServiceDataFilter` interface with `serviceUuid`, `dataPrefix`, and `mask` properties
- Updated `RequestBleDeviceOptions` to include optional `serviceData` parameter
- Implemented client-side service data filtering in `BluetoothLeWeb.ts`
- Added `matchesServiceDataFilter()` method for advertisement filtering

#### **iOS** (`ios/Plugin`)
- Added `ServiceDataFilter` struct in `Plugin.swift`
- Implemented `getServiceDataFilters()` method to parse filter options
- Added `passesServiceDataFilter()` method in `DeviceManager.swift` for filtering logic
- Updated `requestDevice` and `requestLEScan` to accept and apply service data filters

#### **Android** (`android/src/main/java/.../bluetoothle/`)
- Updated `getScanFilters()` in `BluetoothLe.kt` to handle service data filters
- Uses native `ScanFilter.Builder().setServiceData()` for hardware-level filtering
- Supports service UUID, data prefix, and bit mask filtering

### 📚 Usage Example

```typescript
import { BleClient } from '@capacitor-community/bluetooth-le';

// Scan for OpenDroneID devices
await BleClient.requestLEScan(
  {
    serviceData: [
      {
        serviceUuid: '0000fffa-0000-1000-8000-00805f9b34fb',
        dataPrefix: new Uint8Array([0x0D])  // OpenDroneID AD code
      }
    ],
    allowDuplicates: true
  },
  (result) => {
    console.log('Found device:', result);
    console.log('Service data:', result.serviceData);
  }
);
```

### 🧪 Testing

- ✅ TypeScript definitions compile without errors
- ✅ Android: Hardware-level filtering via `ScanFilter.setServiceData()`
- ✅ iOS: Software filtering in scan delegate callback
- ✅ Web: Client-side filtering in advertisement event handler

### 📱 Platform Support

| Platform | Implementation | Filtering Level |
|----------|---------------|----------------|
| Android | `ScanFilter.setServiceData()` | Hardware (most efficient) |
| iOS | `passesServiceDataFilter()` | Software (in delegate) |
| Web | `matchesServiceDataFilter()` | Client-side (JS) |

### 🔧 API Compatibility

- ✅ Backward compatible - `serviceData` is optional
- ✅ Consistent API across all platforms
- ✅ No breaking changes to existing functionality

### 📖 Related Issues

Closes #XXX (if applicable)

### ✅ Checklist

- [x] TypeScript definitions updated
- [x] Android implementation complete
- [x] iOS implementation complete
- [x] Web implementation complete
- [x] No breaking changes
- [x] Documentation comments added
- [x] Example usage provided
