### PR TITLE
Change deviceMap to use ThreadSafeDictionary

### DIFF
--- a/ios/Sources/BluetoothLe/Plugin.swift
+++ b/ios/Sources/BluetoothLe/Plugin.swift
@@ -52,7 +52,7 @@ public class BluetoothLe: CAPPlugin, CAPBridgedPlugin {
     typealias BleCharacteristic = [String: Any]
     typealias BleDescriptor = [String: Any]
     private var deviceManager: DeviceManager?
-    private var deviceMap = [String: Device]()
+    private var deviceMap = ThreadSafeDictionary<String, Device>()
     private var displayStrings = [String: String]()
 
     override public func load() {


### PR DESCRIPTION
Fixes crash on iOS

related to:
https://github.com/capacitor-community/bluetooth-le/discussions/778

and:
https://github.com/capacitor-community/bluetooth-le/issues/779