### PR TITLE
fix: Avoid mutating scan options object (#799, #803)

### DIFF
--- a/src/bleClient.ts
+++ b/src/bleClient.ts
@@ -712,6 +712,7 @@ class BleClientClass implements BleClientInterface {
   }
 
   private validateRequestBleDeviceOptions(options: RequestBleDeviceOptions): RequestBleDeviceOptions {
+    options = { ...options };
     if (options.services) {
       options.services = options.services.map(parseUUID);
     }


### PR DESCRIPTION
Properties on this options object are replaced with encoded versions. By modifying the options object in-place, it was not possible to make subsequent calls with the same object.